### PR TITLE
Fix bug where github project name contains dot.

### DIFF
--- a/src/Plugins/GithubCommit/Configurator.php
+++ b/src/Plugins/GithubCommit/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/commit\/([0-9a-f]{7,40})(#commitcomment-\w+)?(#diff-[\w-]+)?|([\w-]+\/[\w-]+)@([0-9a-f]{7,40}))/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/commit\/([0-9a-f]{7,40})(#commitcomment-\w+)?(#diff-[\w.-]+)?|([\w-]+\/[\w.-]+)@([0-9a-f]{7,40}))/si';
 
     protected $tagName = 'GITHUBCOMMIT';
 

--- a/src/Plugins/GithubCompare/Configurator.php
+++ b/src/Plugins/GithubCompare/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/compare\/([\w\-\.]+)\.\.\.([\w\-\.]+))/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/compare\/([\w\-\.]+)\.\.\.([\w\-\.]+))/si';
 
     protected $tagName = 'GITHUBCOMPARE';
 

--- a/src/Plugins/GithubIssue/Configurator.php
+++ b/src/Plugins/GithubIssue/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/(issues)\/(\d+)(#issuecomment-\d+)?|([\w-]+\/[\w-]+)#(\d+))/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/(issues)\/(\d+)(#issuecomment-\d+)?|([\w.-]+\/[\w.-]+)#(\d+))/si';
     protected $tagName = 'GITHUBISSUE';
 
     protected function getClassName()

--- a/src/Plugins/GithubPullRequest/Configurator.php
+++ b/src/Plugins/GithubPullRequest/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/commits\/[0-9a-f]{7,40})?)/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w.-]+\/[\w.-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/commits\/[0-9a-f]{7,40})?)/si';
     protected $tagName = 'GITHUBPR';
 
     protected function getClassName()

--- a/src/Plugins/GithubRepository/Configurator.php
+++ b/src/Plugins/GithubRepository/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)(\/[^\s]*)?)/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w.-]+\/[\w.-]+)(\/[^\s]*)?)/si';
     protected $tagName = 'GITHUBREPO';
 
     protected function getClassName()


### PR DESCRIPTION
**Fixes #0000**

**Changes proposed in this pull request:**

Fix bug where github project name contains dot.

**Reviewers should focus on:**


**Screenshot**

![image](https://github.com/user-attachments/assets/7a4d4ee7-6389-42ad-8aa6-8187933b4ce4)


**Confirmed**

- [ √] Frontend changes: tested on a local Flarum installation.
- [ √] Backend changes: tests are green (run `composer test`).

**Required changes:**

