### PR TITLE
[2.x] Add Github Release autolink and fix tests

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -24,5 +24,6 @@ return [
             $configurator->plugins->set('GithubCommitAutolink', Plugins\GithubCommit\Configurator::class);
             $configurator->plugins->set('GithubRepositoryAutolink', Plugins\GithubRepository\Configurator::class);
             $configurator->plugins->set('GithubCompareAutolink', Plugins\GithubCompare\Configurator::class);
+            $configurator->plugins->set('GithubReleaseAutolink', Plugins\GithubRelease\Configurator::class);
         }),
 ];

--- a/src/Plugins/GithubRelease/Configurator.php
+++ b/src/Plugins/GithubRelease/Configurator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of fof/github-autolink.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GitHubAutolink\Plugins\GithubRelease;
+
+use FoF\GitHubAutolink\Plugins\Github;
+use s9e\TextFormatter\Configurator\Items\Tag;
+
+class Configurator extends Github
+{
+    protected string $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/releases\/tag\/([\w\-\.]+))/si';
+    protected ?string $tagName = 'GITHUBRELEASE';
+
+    protected function getClassName(): string
+    {
+        return 'github-release-link';
+    }
+
+    protected function getSpecificAttributes(Tag $tag): void
+    {
+        $tag->attributes->add('tag');
+    }
+
+    protected function getTemplateHref(): string
+    {
+        return 'https://github.com/<xsl:value-of select="@repo"/>/releases/tag/<xsl:value-of select="@tag"/>';
+    }
+
+    protected function getTemplateContent(): string
+    {
+        return '<xsl:value-of select="@repo"/><i class="fas fa-tag" aria-hidden="true" /><xsl:value-of select="@tag"/>';
+    }
+
+    public function getJSParser()
+    {
+        return \file_get_contents(realpath(__DIR__.'/Parser.js'));
+    }
+}

--- a/src/Plugins/GithubRelease/Parser.js
+++ b/src/Plugins/GithubRelease/Parser.js
@@ -1,0 +1,9 @@
+matches.forEach(function(m)
+{
+  var tag = addSelfClosingTag(config.tagName, m[0][1], m[0][0].length, -10);
+
+  tag.setAttributes({
+    'repo': m[1][0],
+    'tag': m[2][0]
+  });
+});

--- a/src/Plugins/GithubRelease/Parser.php
+++ b/src/Plugins/GithubRelease/Parser.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of fof/github-autolink.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GitHubAutolink\Plugins\GithubRelease;
+
+use s9e\TextFormatter\Plugins\ParserBase;
+
+class Parser extends ParserBase
+{
+    public function parse($text, array $matches)
+    {
+        $tagName = $this->config['tagName'];
+
+        foreach ($matches as $m) {
+            $tag = $this->parser->addSelfClosingTag(
+                $tagName,
+                $m[0][1],
+                \strlen($m[0][0]),
+                -10
+            );
+
+            $tag->setAttributes(
+                [
+                    'repo'  => $m[1][0],
+                    'tag'   => $m[2][0],
+                ]
+            );
+        }
+    }
+}

--- a/tests/integration/FormatterTest.php
+++ b/tests/integration/FormatterTest.php
@@ -17,6 +17,7 @@ use Flarum\Post\Post;
 use Flarum\Testing\integration\RetrievesAuthorizedUsers;
 use Flarum\Testing\integration\TestCase;
 use Flarum\User\User;
+use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
 
 class FormatterTest extends TestCase
@@ -65,9 +66,7 @@ class FormatterTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_github_pr_link()
     {
         $response = $this->postContent("Here's a PR https://github.com/flarum/framework/pull/3876");
@@ -81,9 +80,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3876"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_github_pr_comment()
     {
         $response = $this->postContent('PR Comment: https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864');
@@ -97,9 +94,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_commit_inside_a_pr()
     {
         $response = $this->postContent('Commit inside a PR: https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2');
@@ -113,9 +108,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_normal_commit()
     {
         $response = $this->postContent('Normal commit: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c');
@@ -129,9 +122,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_commit_comment()
     {
         $response = $this->postContent('Commit comment: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c#commitcomment-129448475');
@@ -145,9 +136,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c#commitcomment-129448475"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_an_issue()
     {
         $response = $this->postContent('Issue: https://github.com/flarum/framework/issues/3895');
@@ -161,9 +150,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/flarum/framework/issues/3895"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_repository()
     {
         $response = $this->postContent('Repo: https://github.com/imorland/flarum-ext-twofactor');
@@ -177,9 +164,7 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/imorland/flarum-ext-twofactor"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_a_compare_link()
     {
         $response = $this->postContent('Compare: https://github.com/flarum/framework/compare/v1.8.2...v1.8.3');
@@ -193,9 +178,22 @@ class FormatterTest extends TestCase
         $this->assertStringContainsString('href="https://github.com/flarum/framework/compare/v1.8.2...v1.8.3"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
+    public function it_renders_a_release_link()
+    {
+        $link = 'https://github.com/flarum/framework/releases/tag/v1.8.3';
+        $response = $this->postContent("Release: $link");
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString('github-release-link', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString("href=\"$link\"", $post['attributes']['contentHtml']);
+    }
+
+    #[Test]
     public function it_renders_all_links_together()
     {
         $content = <<<'EOT'
@@ -207,6 +205,7 @@ Commit comment: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee
 Issue: https://github.com/flarum/framework/issues/3895
 Repo: https://github.com/imorland/flarum-ext-twofactor
 Compare: https://github.com/flarum/framework/compare/v1.8.2...v1.8.3
+Release: https://github.com/flarum/framework/releases/tag/v1.8.3
 EOT;
 
         $response = $this->postContent($content);
@@ -238,11 +237,12 @@ EOT;
 
         $this->assertStringContainsString('github-compare-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/compare/v1.8.2...v1.8.3"', $post['attributes']['contentHtml']);
+
+        $this->assertStringContainsString('github-release-link', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString('href="https://github.com/flarum/framework/releases/tag/v1.8.3"', $post['attributes']['contentHtml']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_renders_undefined_github_links()
     {
         $url = 'https://github.com/EsotericSoftware/spine-runtimes/tree/4.1/spine-sdl#spine-version';


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->


**Changes proposed in this pull request:**
- Turn `/release/tag/<tag>` into a prettier format.
- Fix tests not running by replacing docblock annotation with `#[Test]`

**Reviewers should focus on:**
Tag regex could maybe be expanded but this covers most use cases. I reused the same ref regex as the compare autolink.

**Screenshot**
<img width="370" height="51" alt="image" src="https://github.com/user-attachments/assets/b2e2cf64-ae0c-4e9a-a3df-93aa7f5cf215" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
