### PR TITLE
[2.x] Tidy styling and add support for new PR commit link

### DIFF
--- a/less/forum.less
+++ b/less/forum.less
@@ -1,17 +1,41 @@
 .Github-embed {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   border: 1px solid var(--control-bg);
   border-radius: var(--border-radius);
-  padding: 2px 6px;
+  padding: 0 4px;
   text-decoration: none;
   color: var(--text-color);
   background-color: var(--control-bg);
   font-size: 0.9em;
-  margin: 0 2px;
+  margin: -2px 2px;
 
-  i.fab.fa-github {
-      margin-right: 4px;
+  i.fab.fa-github, .github-repo-name {
+      flex: 0 0 auto;
+  }
+
+  .github-repo-name {
+      white-space: nowrap;
+      margin: 0 4px;
+  }
+
+  // Only allow the path to break if necessary.
+  // If/when it wraps, it'll start a new line and take up the full width.
+  .github-repo-link--path {
+      flex: 1 1 auto;
+      min-width: 0;
+      word-break: break-all;
+      font-weight: 400;
+  }
+
+  // Used in commit, issue, pr, and compare links
+  code {
+    background-color: var(--code-bg);
+    color: var(--code-color);
+    padding: 2px 4px; // Add a little padding for visual balance
+    border-radius: var(--border-radius);
+    font-size: 0.9em;
   }
 
   // Add general styling for FontAwesome icons used in the links
@@ -34,21 +58,5 @@
   &:active {
       background-color: color-mix(in srgb, var(--control-bg), black 10%);
   }
-}
 
-.github-commit-link, .github-issue-link, .github-pr-link {
-  code {
-      background-color: var(--code-bg);
-      color: var(--code-color);
-      padding: 2px 4px; // Add a little padding for visual balance
-      border-radius: var(--border-radius);
-      font-size: 0.9em;
-  }
-}
-
-.github-repo-link {
-    &--path {
-        font-weight: 400;
-        padding-left: 4px;
-    }
 }

--- a/src/Plugins/Github.php
+++ b/src/Plugins/Github.php
@@ -63,7 +63,7 @@ abstract class Github extends ConfiguratorBase
 
     protected function getRepoNameTemplate(): string
     {
-        return "<span class=\"github-repo-name\"><xsl:value-of select=\"@repo\"/></span>";
+        return '<span class="github-repo-name"><xsl:value-of select="@repo"/></span>';
     }
 
     abstract protected function getTemplateHref(): string;

--- a/src/Plugins/Github.php
+++ b/src/Plugins/Github.php
@@ -61,6 +61,11 @@ abstract class Github extends ConfiguratorBase
         );
     }
 
+    protected function getRepoNameTemplate(): string
+    {
+        return "<span class=\"github-repo-name\"><xsl:value-of select=\"@repo\"/></span>";
+    }
+
     abstract protected function getTemplateHref(): string;
 
     abstract protected function getTemplateContent(): string;

--- a/src/Plugins/GithubCommit/Configurator.php
+++ b/src/Plugins/GithubCommit/Configurator.php
@@ -44,9 +44,21 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-hashtag" aria-hidden="true" /><code><xsl:value-of select="substring(@commit, 1, 7)"/></code>
-        <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>
-        <xsl:if test="string(@diff) and @diff != \'\'"> (diff)</xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-hashtag" aria-hidden="true" />
+<code class="github-commit-link--commit">
+    <xsl:value-of select="substring(@commit, 1, 7)"/>
+</code>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+
+<xsl:if test="string(@diff) and @diff != ''">
+    (diff)
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubCompare/Configurator.php
+++ b/src/Plugins/GithubCompare/Configurator.php
@@ -38,7 +38,13 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-arrow-right" aria-hidden="true" /><code><xsl:value-of select="@base"/> → <xsl:value-of select="@head"/></code>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-arrow-right" aria-hidden="true" />
+<code class="github-compare-link--branches">
+    <xsl:value-of select="@base"/> → <xsl:value-of select="@head"/>
+</code>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubIssue/Configurator.php
+++ b/src/Plugins/GithubIssue/Configurator.php
@@ -38,8 +38,17 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-exclamation-circle" aria-hidden="true" /><xsl:value-of select="@issue"/>
-               <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-exclamation-circle" aria-hidden="true" />
+<span class="github-issue-link--number">
+    <xsl:value-of select="@issue"/>
+</span>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubPullRequest/Configurator.php
+++ b/src/Plugins/GithubPullRequest/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected string $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/commits\/[0-9a-f]{7,40})?)/si';
+    protected string $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/(?:commits|changes)\/([0-9a-f]{7,40}))?)/si';
     protected ?string $tagName = 'GITHUBPR';
 
     protected function getClassName(): string
@@ -33,7 +33,7 @@ class Configurator extends Github
 
     protected function getTemplateHref(): string
     {
-        return 'https://github.com/<xsl:value-of select="@repo"/>/pull/<xsl:value-of select="@pr"/><xsl:if test="string(@comment) and @comment != \'\'"><xsl:value-of select="@comment"/></xsl:if><xsl:if test="string(@commit) and @commit != \'\'">/commits/<xsl:value-of select="@commit"/></xsl:if>';
+        return 'https://github.com/<xsl:value-of select="@repo"/>/pull/<xsl:value-of select="@pr"/><xsl:if test="string(@comment) and @comment != \'\'"><xsl:value-of select="@comment"/></xsl:if><xsl:if test="string(@commit) and @commit != \'\'">/changes/<xsl:value-of select="@commit"/></xsl:if>';
     }
 
     protected function getTemplateContent(): string

--- a/src/Plugins/GithubPullRequest/Configurator.php
+++ b/src/Plugins/GithubPullRequest/Configurator.php
@@ -38,9 +38,24 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-code-branch" aria-hidden="true" /><xsl:value-of select="@pr"/>
-            <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>
-            <xsl:if test="string(@commit) and @commit != \'\'"><i class="fas fa-hashtag" aria-hidden="true" /><code><xsl:value-of select="substring(@commit, 1, 7)"/></code></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-code-branch" aria-hidden="true" />
+<span class="github-pr-link--number">
+    <xsl:value-of select="@pr"/>
+</span>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+
+<xsl:if test="string(@commit) and @commit != ''">
+    <i class="fas fa-hashtag" aria-hidden="true" />
+    <code class="github-pr-link--commit">
+        <xsl:value-of select="substring(@commit, 1, 7)"/>
+    </code>
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubPullRequest/Parser.js
+++ b/src/Plugins/GithubPullRequest/Parser.js
@@ -1,15 +1,14 @@
 matches.forEach(function(m) {
   var tag = addSelfClosingTag(config.tagName, m[0][1], m[0][0].length, -100);
-  
+
   var isComment = m[3] && m[3][0].startsWith('#');
-  var isCommit = m[4] && m[4][0].startsWith('/commits/');
 
   var attributes = {
       'repo': m[1][0],
       'pr': m[2][0],
       'comment': isComment ? m[3][0] : '',
-      'commit': isCommit ? m[4][0].split('/commits/')[1] : ''
+      'commit': m[5] && m[5][0] || '',
   };
-  
+
   tag.setAttributes(attributes);
 });

--- a/src/Plugins/GithubPullRequest/Parser.php
+++ b/src/Plugins/GithubPullRequest/Parser.php
@@ -28,13 +28,12 @@ class Parser extends ParserBase
             );
 
             $isComment = isset($m[3]) && \strpos($m[3][0], '#') === 0;
-            $isCommit = isset($m[4]) && \strpos($m[4][0], '/commits/') !== false;
 
             $attributes = [
                 'repo'    => $m[1][0],
                 'pr'      => $m[2][0],
                 'comment' => $isComment ? $m[3][0] : '',
-                'commit'  => $isCommit ? \explode('/commits/', $m[4][0])[1] : '',
+                'commit'  => $m[5][0] ?? '',
             ];
 
             $tag->setAttributes($attributes);

--- a/src/Plugins/GithubRelease/Configurator.php
+++ b/src/Plugins/GithubRelease/Configurator.php
@@ -36,7 +36,13 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-tag" aria-hidden="true" /><xsl:value-of select="@tag"/>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-tag" aria-hidden="true" />
+<span class="github-release-link--tag">
+    <xsl:value-of select="@tag"/>
+</span>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubRepository/Configurator.php
+++ b/src/Plugins/GithubRepository/Configurator.php
@@ -36,7 +36,14 @@ class Configurator extends Github
 
     protected function getTemplateContent(): string
     {
-        return '<xsl:value-of select="@repo"/><xsl:if test="string(@repopath) and @repopath != \'\'"><span class="github-repo-link--path"><xsl:value-of select="substring(@repopath, 2)"/></span></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<xsl:if test="string(@repopath) and @repopath != ''">
+    <span class="github-repo-link--path">
+        <xsl:value-of select="substring(@repopath, 2)"/>
+    </span>
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/tests/integration/FormatterTest.php
+++ b/tests/integration/FormatterTest.php
@@ -105,7 +105,7 @@ class FormatterTest extends TestCase
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
-        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
     }
 
     #[Test]
@@ -200,6 +200,7 @@ class FormatterTest extends TestCase
 Here's a PR https://github.com/flarum/framework/pull/3876
 PR Comment: https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864
 Commit inside a PR: https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2
+Commit inside a PR (new link): https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2
 Normal commit: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c
 Commit comment: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c#commitcomment-129448475
 Issue: https://github.com/flarum/framework/issues/3895
@@ -222,7 +223,9 @@ EOT;
 
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864"', $post['attributes']['contentHtml']);
 
-        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+
+        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
 
         $this->assertStringContainsString('github-commit-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c"', $post['attributes']['contentHtml']);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
- Make box of github links smaller --- allows for better blending in text (primarily vertically), keep line heights the same
- Style `code` for compare link properly
- Add PR `/changes/<sha>` to PR RegEx, update url to new one (old `/commits/<sha>` now seems to redirect so it still works)
- Add `<span>` to repo name so it's not direct text and can be more easily styled; introduced in shared helper method
- Updated templates to be more readable

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<img width="1412" height="574" alt="image" src="https://github.com/user-attachments/assets/2b76b23f-771f-4d9f-b006-77928f31e9d9" />
<img width="1427" height="231" alt="image" src="https://github.com/user-attachments/assets/c0542057-440b-4be0-9ebe-7a9dfdcbbc9b" />
<img width="935" height="104" alt="image" src="https://github.com/user-attachments/assets/576550eb-c612-4303-a48b-b4aed4870a54" />


**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
