### PR TITLE
[1.x] Backport new styling, release autolink, and new PR commit link

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -24,5 +24,6 @@ return [
             $configurator->plugins->set('GithubCommitAutolink', Plugins\GithubCommit\Configurator::class);
             $configurator->plugins->set('GithubRepositoryAutolink', Plugins\GithubRepository\Configurator::class);
             $configurator->plugins->set('GithubCompareAutolink', Plugins\GithubCompare\Configurator::class);
+            $configurator->plugins->set('GithubReleaseAutolink', Plugins\GithubRelease\Configurator::class);
         }),
 ];

--- a/less/forum.less
+++ b/less/forum.less
@@ -1,54 +1,61 @@
 .Github-embed {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   border: 1px solid @control-bg;
   border-radius: @border-radius;
-  padding: 2px 6px;
+  padding: 0 4px;
   text-decoration: none;
   color: @text-color;
   background-color: @control-bg;
   font-size: 0.9em;
-  margin: 0 2px;
+  margin: -2px 2px;
 
-  i.fab.fa-github {
-      margin-right: 4px;
+  i.fab.fa-github, .github-repo-name {
+    flex: 0 0 auto;
+  }
+
+  .github-repo-name {
+    white-space: nowrap;
+    margin: 0 4px;
+  }
+
+  // Only allow the path to break if necessary.
+  // If/when it wraps, it'll start a new line and take up the full width.
+  .github-repo-link--path {
+    flex: 1 1 auto;
+    min-width: 0;
+    word-break: break-all;
+    font-weight: 400;
+  }
+
+  // Used in commit, issue, pr, and compare links
+  code {
+    background-color: var(--code-bg);
+    color: var(--code-color);
+    padding: 2px 4px; // Add a little padding for visual balance
+    border-radius: var(--border-radius);
+    font-size: 0.9em;
   }
 
   // Add general styling for FontAwesome icons used in the links
   i.fas {
-      margin: 0 3px; // Spacing around the icons
-      font-size: 0.85em; // Slightly reduce the size for better visual alignment
+    margin: 0 3px; // Spacing around the icons
+    font-size: 0.85em; // Slightly reduce the size for better visual alignment
   }
 
   i.fas.fa-code-branch,
   i.fas.fa-exclamation-circle,
   i.fas.fa-comment,
   i.fas.fa-hashtag {
-      margin-right: 2px; // Adjust spacing between the repo name and the icons
+    margin-right: 2px; // Adjust spacing between the repo name and the icons
   }
 
   &:hover {
-      background-color: darken(@control-bg, 5%);
+    background-color: darken(@control-bg, 5%);
   }
 
   &:active {
-      background-color: darken(@control-bg, 10%);
+    background-color: darken(@control-bg, 10%);
   }
-}
-
-.github-commit-link, .github-issue-link, .github-pr-link {
-  code {
-      background-color: @code-bg;
-      color: @code-color;
-      padding: 2px 4px; // Add a little padding for visual balance
-      border-radius: @border-radius;
-      font-size: 0.9em;
-  }
-}
-
-.github-repo-link {
-    &--path {
-        font-weight: 400;
-        padding-left: 4px;
-    }
 }

--- a/src/Plugins/Github.php
+++ b/src/Plugins/Github.php
@@ -61,6 +61,11 @@ abstract class Github extends ConfiguratorBase
         );
     }
 
+    protected function getRepoNameTemplate(): string
+    {
+        return '<span class="github-repo-name"><xsl:value-of select="@repo"/></span>';
+    }
+
     abstract protected function getTemplateHref();
 
     abstract protected function getTemplateContent();

--- a/src/Plugins/GithubCommit/Configurator.php
+++ b/src/Plugins/GithubCommit/Configurator.php
@@ -44,9 +44,21 @@ class Configurator extends Github
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-hashtag" aria-hidden="true" /><code><xsl:value-of select="substring(@commit, 1, 7)"/></code>
-        <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>
-        <xsl:if test="string(@diff) and @diff != \'\'"> (diff)</xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-hashtag" aria-hidden="true" />
+<code class="github-commit-link--commit">
+    <xsl:value-of select="substring(@commit, 1, 7)"/>
+</code>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+
+<xsl:if test="string(@diff) and @diff != ''">
+    (diff)
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubCompare/Configurator.php
+++ b/src/Plugins/GithubCompare/Configurator.php
@@ -38,7 +38,13 @@ class Configurator extends Github
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-arrow-right" aria-hidden="true" /><code><xsl:value-of select="@base"/> → <xsl:value-of select="@head"/></code>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-arrow-right" aria-hidden="true" />
+<code class="github-compare-link--branches">
+    <xsl:value-of select="@base"/> → <xsl:value-of select="@head"/>
+</code>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubIssue/Configurator.php
+++ b/src/Plugins/GithubIssue/Configurator.php
@@ -38,8 +38,17 @@ class Configurator extends Github
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-exclamation-circle" aria-hidden="true" /><xsl:value-of select="@issue"/>
-               <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-exclamation-circle" aria-hidden="true" />
+<span class="github-issue-link--number">
+    <xsl:value-of select="@issue"/>
+</span>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubPullRequest/Configurator.php
+++ b/src/Plugins/GithubPullRequest/Configurator.php
@@ -16,7 +16,7 @@ use s9e\TextFormatter\Configurator\Items\Tag;
 
 class Configurator extends Github
 {
-    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/commits\/[0-9a-f]{7,40})?)/si';
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/pull\/(\d+)(#pullrequestreview-\d+)?(\/(?:commits|changes)\/([0-9a-f]{7,40}))?)/si';
     protected $tagName = 'GITHUBPR';
 
     protected function getClassName()
@@ -33,14 +33,29 @@ class Configurator extends Github
 
     protected function getTemplateHref()
     {
-        return 'https://github.com/<xsl:value-of select="@repo"/>/pull/<xsl:value-of select="@pr"/><xsl:if test="string(@comment) and @comment != \'\'"><xsl:value-of select="@comment"/></xsl:if><xsl:if test="string(@commit) and @commit != \'\'">/commits/<xsl:value-of select="@commit"/></xsl:if>';
+        return 'https://github.com/<xsl:value-of select="@repo"/>/pull/<xsl:value-of select="@pr"/><xsl:if test="string(@comment) and @comment != \'\'"><xsl:value-of select="@comment"/></xsl:if><xsl:if test="string(@commit) and @commit != \'\'">/changes/<xsl:value-of select="@commit"/></xsl:if>';
     }
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-code-branch" aria-hidden="true" /><xsl:value-of select="@pr"/>
-            <xsl:if test="string(@comment) and @comment != \'\'"><i class="fas fa-comment" aria-hidden="true" /></xsl:if>
-            <xsl:if test="string(@commit) and @commit != \'\'"><i class="fas fa-hashtag" aria-hidden="true" /><code><xsl:value-of select="substring(@commit, 1, 7)"/></code></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-code-branch" aria-hidden="true" />
+<span class="github-pr-link--number">
+    <xsl:value-of select="@pr"/>
+</span>
+
+<xsl:if test="string(@comment) and @comment != ''">
+    <i class="fas fa-comment" aria-hidden="true" />
+</xsl:if>
+
+<xsl:if test="string(@commit) and @commit != ''">
+    <i class="fas fa-hashtag" aria-hidden="true" />
+    <code class="github-pr-link--commit">
+        <xsl:value-of select="substring(@commit, 1, 7)"/>
+    </code>
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubPullRequest/Parser.js
+++ b/src/Plugins/GithubPullRequest/Parser.js
@@ -1,15 +1,14 @@
 matches.forEach(function(m) {
   var tag = addSelfClosingTag(config.tagName, m[0][1], m[0][0].length, -100);
-  
+
   var isComment = m[3] && m[3][0].startsWith('#');
-  var isCommit = m[4] && m[4][0].startsWith('/commits/');
 
   var attributes = {
       'repo': m[1][0],
       'pr': m[2][0],
       'comment': isComment ? m[3][0] : '',
-      'commit': isCommit ? m[4][0].split('/commits/')[1] : ''
+      'commit': m[5] && m[5][0] || '',
   };
-  
+
   tag.setAttributes(attributes);
 });

--- a/src/Plugins/GithubPullRequest/Parser.php
+++ b/src/Plugins/GithubPullRequest/Parser.php
@@ -28,13 +28,12 @@ class Parser extends ParserBase
             );
 
             $isComment = isset($m[3]) && \strpos($m[3][0], '#') === 0;
-            $isCommit = isset($m[4]) && \strpos($m[4][0], '/commits/') !== false;
 
             $attributes = [
                 'repo'    => $m[1][0],
                 'pr'      => $m[2][0],
                 'comment' => $isComment ? $m[3][0] : '',
-                'commit'  => $isCommit ? \explode('/commits/', $m[4][0])[1] : '',
+                'commit'  => $m[5][0] ?? '',
             ];
 
             $tag->setAttributes($attributes);

--- a/src/Plugins/GithubRelease/Configurator.php
+++ b/src/Plugins/GithubRelease/Configurator.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of fof/github-autolink.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GitHubAutolink\Plugins\GithubRelease;
+
+use FoF\GitHubAutolink\Plugins\Github;
+use s9e\TextFormatter\Configurator\Items\Tag;
+
+class Configurator extends Github
+{
+    protected $regexp = '/(?:^|\b)(?:https?\:\/\/github\.com\/([\w-]+\/[\w-]+)\/releases\/tag\/([\w\-\.]+))/si';
+    protected $tagName = 'GITHUBRELEASE';
+
+    protected function getClassName()
+    {
+        return 'github-release-link';
+    }
+
+    protected function getSpecificAttributes(Tag $tag)
+    {
+        $tag->attributes->add('tag');
+    }
+
+    protected function getTemplateHref()
+    {
+        return 'https://github.com/<xsl:value-of select="@repo"/>/releases/tag/<xsl:value-of select="@tag"/>';
+    }
+
+    protected function getTemplateContent()
+    {
+        return '<xsl:value-of select="@repo"/><i class="fas fa-tag" aria-hidden="true" /><xsl:value-of select="@tag"/>';
+    }
+
+    public function getJSParser()
+    {
+        return \file_get_contents(realpath(__DIR__.'/Parser.js'));
+    }
+}

--- a/src/Plugins/GithubRelease/Configurator.php
+++ b/src/Plugins/GithubRelease/Configurator.php
@@ -36,7 +36,13 @@ class Configurator extends Github
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><i class="fas fa-tag" aria-hidden="true" /><xsl:value-of select="@tag"/>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<i class="fas fa-tag" aria-hidden="true" />
+<span class="github-release-link--tag">
+    <xsl:value-of select="@tag"/>
+</span>
+XML;
     }
 
     public function getJSParser()

--- a/src/Plugins/GithubRelease/Parser.js
+++ b/src/Plugins/GithubRelease/Parser.js
@@ -1,0 +1,9 @@
+matches.forEach(function(m)
+{
+  var tag = addSelfClosingTag(config.tagName, m[0][1], m[0][0].length, -10);
+
+  tag.setAttributes({
+    'repo': m[1][0],
+    'tag': m[2][0]
+  });
+});

--- a/src/Plugins/GithubRelease/Parser.php
+++ b/src/Plugins/GithubRelease/Parser.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of fof/github-autolink.
+ *
+ * Copyright (c) FriendsOfFlarum.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FoF\GitHubAutolink\Plugins\GithubRelease;
+
+use s9e\TextFormatter\Plugins\ParserBase;
+
+class Parser extends ParserBase
+{
+    public function parse($text, array $matches)
+    {
+        $tagName = $this->config['tagName'];
+
+        foreach ($matches as $m) {
+            $tag = $this->parser->addSelfClosingTag(
+                $tagName,
+                $m[0][1],
+                \strlen($m[0][0]),
+                -10
+            );
+
+            $tag->setAttributes(
+                [
+                    'repo'  => $m[1][0],
+                    'tag'   => $m[2][0],
+                ]
+            );
+        }
+    }
+}

--- a/src/Plugins/GithubRepository/Configurator.php
+++ b/src/Plugins/GithubRepository/Configurator.php
@@ -36,7 +36,14 @@ class Configurator extends Github
 
     protected function getTemplateContent()
     {
-        return '<xsl:value-of select="@repo"/><xsl:if test="string(@repopath) and @repopath != \'\'"><span class="github-repo-link--path"><xsl:value-of select="substring(@repopath, 2)"/></span></xsl:if>';
+        return <<<XML
+{$this->getRepoNameTemplate()}
+<xsl:if test="string(@repopath) and @repopath != ''">
+    <span class="github-repo-link--path">
+        <xsl:value-of select="substring(@repopath, 2)"/>
+    </span>
+</xsl:if>
+XML;
     }
 
     public function getJSParser()

--- a/tests/integration/FormatterTest.php
+++ b/tests/integration/FormatterTest.php
@@ -193,6 +193,23 @@ class FormatterTest extends TestCase
     /**
      * @test
      */
+    public function it_renders_a_release_link()
+    {
+        $link = 'https://github.com/flarum/framework/releases/tag/v1.8.3';
+        $response = $this->postContent("Release: $link");
+
+        $this->assertEquals(201, $response->getStatusCode());
+
+        $post = json_decode($response->getBody()->getContents(), true)['data'];
+
+        $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString('github-release-link', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString("href=\"$link\"", $post['attributes']['contentHtml']);
+    }
+
+    /**
+     * @test
+     */
     public function it_renders_all_links_together()
     {
         $content = <<<'EOT'

--- a/tests/integration/FormatterTest.php
+++ b/tests/integration/FormatterTest.php
@@ -107,7 +107,7 @@ class FormatterTest extends TestCase
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
-        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
     }
 
     /**
@@ -216,6 +216,7 @@ class FormatterTest extends TestCase
 Here's a PR https://github.com/flarum/framework/pull/3876
 PR Comment: https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864
 Commit inside a PR: https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2
+Commit inside a PR (new link): https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2
 Normal commit: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c
 Commit comment: https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c#commitcomment-129448475
 Issue: https://github.com/flarum/framework/issues/3895
@@ -237,7 +238,9 @@ EOT;
 
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864"', $post['attributes']['contentHtml']);
 
-        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+        $this->assertStringNotContainsString('href="https://github.com/flarum/framework/pull/3877/commits/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
+
+        $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
 
         $this->assertStringContainsString('github-commit-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c"', $post['attributes']['contentHtml']);


### PR DESCRIPTION
<!--
IMPORTANT: We LOVE seeing new pull requests, they excite us every single time they are submitted! As we have an obligation to maintain a healthy code standard, quality, and extensions, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->


**Changes proposed in this pull request:**
- Add GitHub Release autolink (backport PR #10)
  - Turn /release/tag/<tag> into a prettier format.
- Improve styling and support /changes/ PR link (backport #11)
  - Make box of github links smaller --- allows for better blending in text (primarily vertically), keep line heights the same
  - Style `code` for compare link properly
  - Add PR `/changes/<sha>` to PR RegEx, update url to new one (old `/commits/<sha>` now seems to redirect so it still works)
  - Add `<span>` to repo name so it's not direct text and can be more easily styled; introduced in shared helper method
  - Updated templates to be more readable

**Reviewers should focus on:**
<!-- fill this out, ask for feedback on specific changes you are unsure about -->

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
