### PR TITLE
[2.x] fix: Ensure GitHub links open in a new tab, update phpunit config for v12

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 vendor
 composer.lock
 .phpunit.result.cache
+.phpunit.cache

--- a/src/Plugins/Github.php
+++ b/src/Plugins/Github.php
@@ -48,10 +48,8 @@ abstract class Github extends ConfiguratorBase
     protected function makeTemplate(): string
     {
         return sprintf(
-            '<a class="Github-embed %1$s">
+            '<a class="Github-embed %1$s" target="_blank" rel="ugc noopener noreferrer">
             <xsl:attribute name="href">%2$s</xsl:attribute>
-            <xsl:attribute name="target">_blank</xsl:attribute>
-            <xsl:attribute name="rel">ugc noopener noreferrer</xsl:attribute>
             <i class="fab fa-github" aria-hidden="true" />
             %3$s
         </a>',

--- a/tests/integration/FormatterTest.php
+++ b/tests/integration/FormatterTest.php
@@ -66,6 +66,16 @@ class FormatterTest extends TestCase
         );
     }
 
+    /**
+     * Every rendered GitHub link must open in a new tab, with a safe rel.
+     */
+    protected function assertOpensInNewTab(string $html, int $expectedLinks = 1): void
+    {
+        $this->assertSame($expectedLinks, substr_count($html, 'Github-embed'));
+        $this->assertSame($expectedLinks, substr_count($html, 'target="_blank"'));
+        $this->assertSame($expectedLinks, substr_count($html, 'rel="ugc noopener noreferrer"'));
+    }
+
     #[Test]
     public function it_renders_a_github_pr_link()
     {
@@ -76,6 +86,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3876"', $post['attributes']['contentHtml']);
     }
@@ -90,6 +101,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3872#pullrequestreview-1585769864"', $post['attributes']['contentHtml']);
     }
@@ -104,6 +116,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/pull/3877/changes/7a94f011df1a3c3f9f32f72c11b1efa9ca17acd2"', $post['attributes']['contentHtml']);
     }
@@ -118,6 +131,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-commit-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c"', $post['attributes']['contentHtml']);
     }
@@ -132,6 +146,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-commit-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/FriendsOfFlarum/default-group/commit/ca783dee209fe126b677ec73a18d1ed4ccc4e76c#commitcomment-129448475"', $post['attributes']['contentHtml']);
     }
@@ -146,6 +161,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-issue-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/issues/3895"', $post['attributes']['contentHtml']);
     }
@@ -160,6 +176,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-repo-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/imorland/flarum-ext-twofactor"', $post['attributes']['contentHtml']);
     }
@@ -174,6 +191,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-compare-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="https://github.com/flarum/framework/compare/v1.8.2...v1.8.3"', $post['attributes']['contentHtml']);
     }
@@ -189,6 +207,7 @@ class FormatterTest extends TestCase
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-release-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString("href=\"$link\"", $post['attributes']['contentHtml']);
     }
@@ -216,6 +235,7 @@ EOT;
         $post = json_decode($response->getBody()->getContents(), true)['data'];
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml'], 10);
 
         // Assert all the strings for each link type
         $this->assertStringContainsString('github-pr-link', $post['attributes']['contentHtml']);
@@ -258,6 +278,7 @@ EOT;
         // Should render the normal repo link, with the full href supplied in the content
 
         $this->assertStringContainsString('Github-embed', $post['attributes']['contentHtml']);
+        $this->assertOpensInNewTab($post['attributes']['contentHtml']);
         $this->assertStringContainsString('github-repo-link', $post['attributes']['contentHtml']);
         $this->assertStringContainsString('href="'.$url.'"', $post['attributes']['contentHtml']);
     }

--- a/tests/phpunit.integration.xml
+++ b/tests/phpunit.integration.xml
@@ -1,25 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="true"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Integration Tests">
             <directory suffix="Test.php">./integration</directory>
-             <exclude>./integration/tmp</exclude>
+            <exclude>./integration/tmp</exclude>
         </testsuite>
     </testsuites>
 </phpunit>

--- a/tests/phpunit.unit.xml
+++ b/tests/phpunit.unit.xml
@@ -1,27 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="../vendor/phpunit/phpunit/phpunit.xsd"
     backupGlobals="false"
-    backupStaticAttributes="false"
+    cacheDirectory=".phpunit.cache"
+    backupStaticProperties="false"
     colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
 >
-    <coverage processUncoveredFiles="true">
+    <source>
         <include>
             <directory suffix=".php">../src/</directory>
         </include>
-    </coverage>
+    </source>
     <testsuites>
         <testsuite name="Flarum Unit Tests">
             <directory suffix="Test.php">./unit</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener class="\Mockery\Adapter\Phpunit\TestListener" />
-    </listeners>
 </phpunit>


### PR DESCRIPTION
Adds test coverage asserting every rendered GitHub link carries `target="_blank"` and `rel="ugc noopener noreferrer"`, and updates the phpunit XML configs to the v12 format so the suite stops emitting a deprecation.